### PR TITLE
feat(copyFile): use native fs.copyFile when available

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -160,21 +160,26 @@ function appendFileSync(path, data, options) {
   fs.appendFileSync(path, data, options);
 }
 
-function copyFile(src, dest, callback) {
+const _copyFile = fs.copyFile ? Promise.promisify(fs.copyFile) : function(src, dest) {
+  return new Promise(function(resolve, reject) {
+    var rs = createReadStream(src);
+    var ws = createWriteStream(dest);
+
+    rs.pipe(ws).on('error', reject);
+
+    ws.on('close', resolve).on('error', reject);
+  });
+};
+
+function copyFile(src, dest, flags, callback) {
   if (!src) throw new TypeError('src is required!');
   if (!dest) throw new TypeError('dest is required!');
+  if (typeof flags === 'function') {
+    callback = flags;
+  }
 
   return checkParent(dest).then(function() {
-    return new Promise(function(resolve, reject) {
-      var rs = createReadStream(src);
-      var ws = createWriteStream(dest);
-
-      rs.pipe(ws)
-        .on('error', reject);
-
-      ws.on('close', resolve)
-        .on('error', reject);
-    });
+    return _copyFile(src, dest, flags);
   }).asCallback(callback);
 }
 


### PR DESCRIPTION
use native `fs.copyFile` when available, closes #8 
I suggest we schedule this change as 0.2.3 as it does not introduce any breaking changes on our API.