### PR TITLE
Tester use iferr

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "chai": "^4.1.2",
     "eslint": "^4.19.1",
     "eslint-config-hexo": "^3.0.0",
+    "iferr": "^1.0.2",
     "istanbul": "^0.4.3",
     "mocha": "^5.1.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -47,7 +47,12 @@ describe('fs', function() {
 
   it('exists() - callback', function(callback) {
     fs.exists(tmpDir, function(exist) {
-      exist.should.be.true;
+      try {
+        exist.should.be.true;
+      } catch (e) {
+        callback(e);
+        return;
+      }
       callback();
     });
   });
@@ -969,7 +974,12 @@ describe('fs', function() {
     createDummyFolder(target).asCallback(tiferr(callback, function() {
       fs.rmdir(target, tiferr(callback, function() {
         fs.exists(target, function(exist) {
-          exist.should.be.false;
+          try {
+            exist.should.be.false;
+          } catch (e) {
+            callback(e);
+            return;
+          }
           callback();
         });
       }));

--- a/test/index.js
+++ b/test/index.js
@@ -69,7 +69,7 @@ describe('fs', () => {
     fs.mkdirs(target, tiferr(callback, () => {
       fs.exists(target, exist => {
         exist.should.be.true;
-        return fs.rmdir(pathFn.join(tmpDir, 'a'));
+        fs.rmdir(pathFn.join(tmpDir, 'a'), callback);
       });
     }));
   });


### PR DESCRIPTION
`iferr` package has useful functions for error handling of first error callback.
At present, methods were mixed in callback related unit tests, but we unified them into `tiferr()`.
`Promise.all()` and `Bluebird.map()` are very difficult to control with callback, but otherwise it is no longer mixed with `Promise.then()` while callback is tested by using `Bluebird.asCallback()` and `tiferr()`.