### PR TITLE
Reduce scope such as recursive function

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -337,9 +337,9 @@ function _emptyDir(path, options, parent) {
       const currentPath = join(parent, item.path);
 
       if (item.isDirectory) {
-        return _emptyDir(fullPath, options, currentPath).then(removed => readdirAsync(fullPath).then(files => {
+        return _emptyDir(fullPath, options, currentPath).tap(() => readdirAsync(fullPath).then(files => {
           if (!files.length) return rmdirAsync(fullPath);
-        }).thenReturn(removed));
+        }));
       }
 
       return unlinkAsync(fullPath).thenReturn(currentPath);

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -450,20 +450,13 @@ function watch(path, options, callback) {
 function _findUnusedPath(path, files) {
   const ext = extname(path);
   const base = basename(path, ext);
-  const regex = new RegExp(`^${escapeRegExp(base)}(?:-(\\d+))?${escapeRegExp(ext)}$`);
-  let num = -1;
+  const regex = new RegExp(`^${escapeRegExp(base)}-(\\d+)${escapeRegExp(ext)}$`);
 
-  for (let i = 0, len = files.length; i < len; i++) {
-    const item = files[i];
-    if (!regex.test(item)) continue;
+  const num = files.reduce((_num, item) => {
+    const match = regex.exec(item);
 
-    const match = item.match(regex);
-    const matchNum = match[1] ? parseInt(match[1], 10) : 0;
-
-    if (matchNum > num) {
-      num = matchNum;
-    }
-  }
+    return match != null ? Math.max(parseInt(match[1], 10), _num) : _num;
+  }, -1);
 
   return join(dirname(path), `${base}-${num + 1}${ext}`);
 }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -436,15 +436,12 @@ function watch(path, options, callback) {
     options = {};
   }
 
+  const watcher = chokidar.watch(path, options);
+
   return new Promise((resolve, reject) => {
-    const watcher = chokidar.watch(path, options);
-
-    watcher.on('ready', () => {
-      resolve(watcher);
-    });
-
+    watcher.on('ready', resolve);
     watcher.on('error', reject);
-  }).asCallback(callback);
+  }).thenReturn(watcher).asCallback(callback);
 }
 
 function _findUnusedPath(path, files) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -217,7 +217,7 @@ function _readAndFilterDirSync(path, options) {
 }
 
 function _copyDir(src, dest, options = {}, parent = '') {
-  return checkParent(dest).then(() => _readAndFilterDir(src, options))
+  return _readAndFilterDir(src, options)
     .map(item => {
       const childSrc = item.fullPath;
       const childDest = join(dest, item.path);
@@ -240,7 +240,7 @@ function copyDir(src, dest, options, callback) {
     options = {};
   }
 
-  return _copyDir(src, dest, options).asCallback(callback);
+  return checkParent(dest).then(() => _copyDir(src, dest, options)).asCallback(callback);
 }
 
 function _listDir(path, options = {}, parent = '') {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -221,13 +221,13 @@ function _copyDir(src, dest, options = {}, parent = '') {
     .map(item => {
       const childSrc = item.fullPath;
       const childDest = join(dest, item.path);
+      const currentPath = join(parent, item.path);
 
       if (item.isDirectory) {
-        return _copyDir(childSrc, childDest, options, join(parent, item.path));
+        return _copyDir(childSrc, childDest, options, currentPath);
       }
 
-      return copyFile(childSrc, childDest, options)
-        .thenReturn(join(parent, item.path));
+      return copyFile(childSrc, childDest, options).thenReturn(currentPath);
     }).reduce(reduceFiles, []);
 }
 
@@ -245,11 +245,13 @@ function copyDir(src, dest, options, callback) {
 
 function _listDir(path, options = {}, parent = '') {
   return _readAndFilterDir(path, options).map(item => {
+    const currentPath = join(parent, item.path);
+
     if (item.isDirectory) {
-      return _listDir(item.fullPath, options, join(parent, item.path));
+      return _listDir(item.fullPath, options, currentPath);
     }
 
-    return join(parent, item.path);
+    return currentPath;
   }).reduce(reduceFiles, []);
 }
 
@@ -268,11 +270,13 @@ function listDirSync(path, options = {}, parent = '') {
   if (!path) throw new TypeError('path is required!');
 
   return _readAndFilterDirSync(path, options).map(item => {
+    const currentPath = join(parent, item.path);
+
     if (item.isDirectory) {
-      return listDirSync(item.fullPath, options, join(parent, item.path));
+      return listDirSync(item.fullPath, options, currentPath);
     }
 
-    return join(parent, item.path);
+    return currentPath;
   }).reduce(reduceFiles, []);
 }
 
@@ -327,14 +331,15 @@ function _emptyDir(path, options = {}, parent = '') {
     .filter(ignoreExcludeFiles(options.exclude, parent))
     .map(item => {
       const fullPath = item.fullPath;
+      const currentPath = join(parent, item.path);
 
       if (item.isDirectory) {
-        return _emptyDir(fullPath, options, join(parent, item.path)).then(removed => readdirAsync(fullPath).then(files => {
+        return _emptyDir(fullPath, options, currentPath).then(removed => readdirAsync(fullPath).then(files => {
           if (!files.length) return rmdirAsync(fullPath);
         }).thenReturn(removed));
       }
 
-      return unlinkAsync(fullPath).thenReturn(join(parent, item.path));
+      return unlinkAsync(fullPath).thenReturn(currentPath);
     }).reduce(reduceFiles, []);
 }
 
@@ -356,9 +361,10 @@ function emptyDirSync(path, options = {}, parent = '') {
     .filter(ignoreExcludeFiles(options.exclude, parent))
     .map(item => {
       const childPath = item.fullPath;
+      const currentPath = join(parent, item.path);
 
       if (item.isDirectory) {
-        const removed = emptyDirSync(childPath, options, join(parent, item.path));
+        const removed = emptyDirSync(childPath, options, currentPath);
 
         if (!fs.readdirSync(childPath).length) {
           rmdirSync(childPath);
@@ -368,7 +374,7 @@ function emptyDirSync(path, options = {}, parent = '') {
       }
 
       fs.unlinkSync(childPath);
-      return join(parent, item.path);
+      return currentPath;
     }).reduce(reduceFiles, []);
 }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -216,7 +216,7 @@ function _readAndFilterDirSync(path, options) {
     });
 }
 
-function _copyDir(src, dest, options = {}, parent = '') {
+function _copyDir(src, dest, options, parent) {
   return _readAndFilterDir(src, options)
     .map(item => {
       const childSrc = item.fullPath;
@@ -231,7 +231,7 @@ function _copyDir(src, dest, options = {}, parent = '') {
     }).reduce(reduceFiles, []);
 }
 
-function copyDir(src, dest, options, callback) {
+function copyDir(src, dest, options = {}, callback) {
   if (!src) throw new TypeError('src is required!');
   if (!dest) throw new TypeError('dest is required!');
 
@@ -240,10 +240,10 @@ function copyDir(src, dest, options, callback) {
     options = {};
   }
 
-  return checkParent(dest).then(() => _copyDir(src, dest, options)).asCallback(callback);
+  return checkParent(dest).then(() => _copyDir(src, dest, options, '')).asCallback(callback);
 }
 
-function _listDir(path, options = {}, parent = '') {
+function _listDir(path, options, parent) {
   return _readAndFilterDir(path, options).map(item => {
     const currentPath = join(parent, item.path);
 
@@ -255,7 +255,7 @@ function _listDir(path, options = {}, parent = '') {
   }).reduce(reduceFiles, []);
 }
 
-function listDir(path, options, callback) {
+function listDir(path, options = {}, callback) {
   if (!path) throw new TypeError('path is required!');
 
   if (!callback && typeof options === 'function') {
@@ -263,10 +263,10 @@ function listDir(path, options, callback) {
     options = {};
   }
 
-  return _listDir(path, options).asCallback(callback);
+  return _listDir(path, options, '').asCallback(callback);
 }
 
-function _listDirSync(path, options = {}, parent = '') {
+function _listDirSync(path, options, parent) {
   return _readAndFilterDirSync(path, options).map(item => {
     const currentPath = join(parent, item.path);
 
@@ -281,7 +281,7 @@ function _listDirSync(path, options = {}, parent = '') {
 function listDirSync(path, options = {}) {
   if (!path) throw new TypeError('path is required!');
 
-  return _listDirSync(path, options);
+  return _listDirSync(path, options, '');
 }
 
 function escapeEOL(str) {
@@ -296,7 +296,7 @@ function escapeFileContent(content) {
   return escapeBOM(escapeEOL(content));
 }
 
-function readFile(path, options, callback) {
+function readFile(path, options = {}, callback) {
   if (!path) throw new TypeError('path is required!');
 
   if (!callback && typeof options === 'function') {
@@ -304,7 +304,6 @@ function readFile(path, options, callback) {
     options = {};
   }
 
-  options = options || {};
   if (!options.hasOwnProperty('encoding')) options.encoding = 'utf8';
 
   return readFileAsync(path, options).then(content => {
@@ -330,7 +329,7 @@ function readFileSync(path, options = {}) {
   return content;
 }
 
-function _emptyDir(path, options = {}, parent = '') {
+function _emptyDir(path, options, parent) {
   return _readAndFilterDir(path, options)
     .filter(ignoreExcludeFiles(options.exclude, parent))
     .map(item => {
@@ -347,7 +346,7 @@ function _emptyDir(path, options = {}, parent = '') {
     }).reduce(reduceFiles, []);
 }
 
-function emptyDir(path, options, callback) {
+function emptyDir(path, options = {}, callback) {
   if (!path) throw new TypeError('path is required!');
 
   if (!callback && typeof options === 'function') {
@@ -355,10 +354,10 @@ function emptyDir(path, options, callback) {
     options = {};
   }
 
-  return _emptyDir(path, options).asCallback(callback);
+  return _emptyDir(path, options, '').asCallback(callback);
 }
 
-function _emptyDirSync(path, options = {}, parent = '') {
+function _emptyDirSync(path, options, parent) {
   return _readAndFilterDirSync(path, options)
     .filter(ignoreExcludeFiles(options.exclude, parent))
     .map(item => {
@@ -380,10 +379,10 @@ function _emptyDirSync(path, options = {}, parent = '') {
     }).reduce(reduceFiles, []);
 }
 
-function emptyDirSync(path, options) {
+function emptyDirSync(path, options = {}) {
   if (!path) throw new TypeError('path is required!');
 
-  return _emptyDirSync(path, options);
+  return _emptyDirSync(path, options, '');
 }
 
 function _rmdir(path) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -266,18 +266,22 @@ function listDir(path, options, callback) {
   return _listDir(path, options).asCallback(callback);
 }
 
-function listDirSync(path, options = {}, parent = '') {
-  if (!path) throw new TypeError('path is required!');
-
+function _listDirSync(path, options = {}, parent = '') {
   return _readAndFilterDirSync(path, options).map(item => {
     const currentPath = join(parent, item.path);
 
     if (item.isDirectory) {
-      return listDirSync(item.fullPath, options, currentPath);
+      return _listDirSync(item.fullPath, options, currentPath);
     }
 
     return currentPath;
   }).reduce(reduceFiles, []);
+}
+
+function listDirSync(path, options = {}) {
+  if (!path) throw new TypeError('path is required!');
+
+  return _listDirSync(path, options);
 }
 
 function escapeEOL(str) {
@@ -354,9 +358,7 @@ function emptyDir(path, options, callback) {
   return _emptyDir(path, options).asCallback(callback);
 }
 
-function emptyDirSync(path, options = {}, parent = '') {
-  if (!path) throw new TypeError('path is required!');
-
+function _emptyDirSync(path, options = {}, parent = '') {
   return _readAndFilterDirSync(path, options)
     .filter(ignoreExcludeFiles(options.exclude, parent))
     .map(item => {
@@ -364,7 +366,7 @@ function emptyDirSync(path, options = {}, parent = '') {
       const currentPath = join(parent, item.path);
 
       if (item.isDirectory) {
-        const removed = emptyDirSync(childPath, options, currentPath);
+        const removed = _emptyDirSync(childPath, options, currentPath);
 
         if (!fs.readdirSync(childPath).length) {
           rmdirSync(childPath);
@@ -378,25 +380,33 @@ function emptyDirSync(path, options = {}, parent = '') {
     }).reduce(reduceFiles, []);
 }
 
-function rmdir(path, callback) {
+function emptyDirSync(path, options) {
   if (!path) throw new TypeError('path is required!');
 
+  return _emptyDirSync(path, options);
+}
+
+function _rmdir(path) {
   return readdirAsync(path).map(item => {
     const childPath = join(path, item);
 
     return statAsync(childPath).then(stats => {
       if (stats.isDirectory()) {
-        return rmdir(childPath);
+        return _rmdir(childPath);
       }
 
       return unlinkAsync(childPath);
     });
-  }).then(() => rmdirAsync(path)).asCallback(callback);
+  }).then(() => rmdirAsync(path));
 }
 
-function rmdirSync(path) {
+function rmdir(path, callback) {
   if (!path) throw new TypeError('path is required!');
 
+  return _rmdir(path).asCallback(callback);
+}
+
+function _rmdirSync(path) {
   const files = fs.readdirSync(path);
 
   for (let i = 0, len = files.length; i < len; i++) {
@@ -404,13 +414,19 @@ function rmdirSync(path) {
     const stats = fs.statSync(childPath);
 
     if (stats.isDirectory()) {
-      rmdirSync(childPath);
+      _rmdirSync(childPath);
     } else {
       fs.unlinkSync(childPath);
     }
   }
 
   fs.rmdirSync(path);
+}
+
+function rmdirSync(path) {
+  if (!path) throw new TypeError('path is required!');
+
+  _rmdirSync(path);
 }
 
 function watch(path, options, callback) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -499,7 +499,7 @@ function ensureWriteStreamSync(path, options) {
 ['F_OK', 'R_OK', 'W_OK', 'X_OK'].forEach(key => {
   Object.defineProperty(exports, key, {
     enumerable: true,
-    value: (fs.constants || fs)[key],
+    value: fs.constants[key],
     writable: false
   });
 });


### PR DESCRIPTION
javascript is hard to optimize for recursive functions.
It would be hopeless to optimize asynchronous functions that span many lines of complexity and do not use async/await.
Therefore, we will try to reduce the complexity by making the recursion place as simple as possible.