### PR TITLE
chore: deprecate npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-test/
-tmp/
-coverage/
-*.log
-.jshintrc
-.travis.yml
-.idea/
-appveyor.yml

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hexo-fs",
   "version": "1.0.2",
   "description": "File system module for Hexo.",
-  "main": "lib/fs",
+  "main": "lib/fs.js",
   "scripts": {
     "eslint": "eslint .",
     "test": "mocha test/index.js",


### PR DESCRIPTION
`files` property is already defined.