### PR TITLE
refactor(test): async/await

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "eslint": "^6.0.1",
-    "eslint-config-hexo": "^4.0.0",
+    "eslint-config-hexo": "^4.1.0",
     "iferr": "^1.0.2",
     "mocha": "^6.0.2",
     "nyc": "^14.1.1"

--- a/test/index.js
+++ b/test/index.js
@@ -1093,7 +1093,9 @@ describe('fs', () => {
 
     stream.on('error', callback);
     stream.on('close', () => {
-      fs.unlink(target, callback);
+      fs.exists(target, exist => {
+        if (exist) fs.unlink(target, callback);
+      });
     });
 
     stream.end();

--- a/test/index.js
+++ b/test/index.js
@@ -1008,7 +1008,7 @@ describe('fs', () => {
 
   it('ensurePath() - callback', callback => {
     const target = join(tmpDir, 'test');
-    const filenames = ['foo.txt', 'foo-1.txt', 'foo-2.md', 'bar.txt'];
+    const filenames = ['foo.txt', 'foo-1.txt', 'foo-2.md', 'baz.txt'];
 
     Promise.map(filenames, path => fs.writeFile(join(target, path))).asCallback(tiferr(callback, () => {
       fs.ensurePath(join(target, 'foo.txt'), tiferr(callback, path => {
@@ -1028,7 +1028,7 @@ describe('fs', () => {
 
   it('ensurePathSync() - file exists', async () => {
     const target = join(tmpDir, 'test');
-    const filenames = ['foo.txt', 'foo-1.txt', 'foo-2.md', 'bar.txt'];
+    const filenames = ['foo.txt', 'foo-1.txt', 'foo-2.md', 'boz.txt'];
 
     await Promise.map(filenames, path => fs.writeFile(join(target, path)));
     const path = fs.ensurePathSync(join(target, 'foo.txt'));
@@ -1072,7 +1072,7 @@ describe('fs', () => {
   });
 
   it('ensureWriteStream() - callback', callback => {
-    const target = join(tmpDir, 'foo', 'bara.txt');
+    const target = join(tmpDir, 'foo', 'barb.txt');
 
     fs.ensureWriteStream(target, tiferr(callback, stream => {
       stream.path.should.eql(target);

--- a/test/index.js
+++ b/test/index.js
@@ -33,7 +33,7 @@ describe('fs', () => {
 
   before(() => fs.mkdirs(tmpDir));
 
-  after(async () => await fs.rmdir(tmpDir));
+  after(() => fs.rmdir(tmpDir));
 
   it('exists()', async () => {
     const exist = await fs.exists(tmpDir);
@@ -993,6 +993,9 @@ describe('fs', () => {
     await Promise.map(filenames, path => fs.writeFile(join(target, path)));
     const result = await fs.ensurePath(join(target, 'foo.txt'));
     result.should.eql(join(target, 'foo-2.txt'));
+
+    const exist = await fs.exists(join(target, 'bar.txt'));
+    if (exist) await fs.unlink(join(target, 'bar.txt'));
 
     await fs.rmdir(target);
   });

--- a/test/index.js
+++ b/test/index.js
@@ -33,10 +33,7 @@ describe('fs', () => {
 
   before(() => fs.mkdirs(tmpDir));
 
-  after(async () => {
-    const exist = await fs.exists(tmpDir);
-    if (exist) fs.rmdir(tmpDir);
-  });
+  after(() => fs.rmdir(tmpDir));
 
   it('exists()', async () => {
     const exist = await fs.exists(tmpDir);
@@ -1096,7 +1093,7 @@ describe('fs', () => {
 
     stream.on('error', callback);
     stream.on('close', () => {
-      fs.rmdir(dirname(target), callback);
+      fs.unlink(target, callback);
     });
 
     stream.end();

--- a/test/index.js
+++ b/test/index.js
@@ -1060,12 +1060,12 @@ describe('fs', () => {
       stream.on('close', resolve('success'));
     });
 
+    stream.end();
     const result = await streamPromise;
     result.should.eql('success');
 
     const exist = await fs.exists(target);
     if (exist) await fs.unlink(target);
-    stream.end();
   });
 
   it('ensureWriteStream() - callback', callback => {
@@ -1076,7 +1076,9 @@ describe('fs', () => {
 
       stream.on('error', callback);
       stream.on('close', () => {
-        fs.unlink(target, callback);
+        fs.exists(target, exist => {
+          if (exist) fs.unlink(target, callback);
+        });
       });
 
       stream.end();

--- a/test/index.js
+++ b/test/index.js
@@ -1052,23 +1052,20 @@ describe('fs', () => {
     }
   });
 
-  it('ensureWriteStream()', async () => {
+  it('ensureWriteStream()', () => {
     const target = join(tmpDir, 'foo', 'bar.txt');
 
-    const stream = await fs.ensureWriteStream(target);
-    stream.path.should.eql(target);
+    return fs.ensureWriteStream(target).then(stream => {
+      stream.path.should.eql(target);
 
-    const streamPromise = new Promise((resolve, reject) => {
-      stream.on('error', reject);
-      stream.on('close', resolve('success'));
-    });
+      const streamPromise = new Promise((resolve, reject) => {
+        stream.on('error', reject);
+        stream.on('close', resolve);
+      });
 
-    stream.end();
-    const result = await streamPromise;
-    result.should.eql('success');
-
-    const exist = await fs.exists(target);
-    if (exist) await fs.unlink(target);
+      stream.end();
+      return streamPromise;
+    }).then(() => fs.unlink(target));
   });
 
   it('ensureWriteStream() - callback', callback => {

--- a/test/index.js
+++ b/test/index.js
@@ -1052,24 +1052,27 @@ describe('fs', () => {
     }
   });
 
-  it('ensureWriteStream()', () => {
-    const target = join(tmpDir, 'foo', 'bar.txt');
+  it('ensureWriteStream()', async () => {
+    const target = join(tmpDir, 'foo', 'bara.txt');
 
-    return fs.ensureWriteStream(target).then(stream => {
-      stream.path.should.eql(target);
+    const stream = await fs.ensureWriteStream(target);
+    stream.path.should.eql(target);
 
-      const streamPromise = new Promise((resolve, reject) => {
-        stream.on('error', reject);
-        stream.on('close', resolve);
-      });
+    const streamPromise = new Promise((resolve, reject) => {
+      stream.on('error', reject);
+      stream.on('close', resolve('success'));
+    });
 
-      stream.end();
-      return streamPromise;
-    }).then(() => fs.unlink(target));
+    stream.end();
+    const result = await streamPromise;
+    result.should.eql('success');
+
+    const exist = await fs.exists(target);
+    if (exist) await fs.unlink(target);
   });
 
   it('ensureWriteStream() - callback', callback => {
-    const target = join(tmpDir, 'foo', 'bar.txt');
+    const target = join(tmpDir, 'foo', 'bara.txt');
 
     fs.ensureWriteStream(target, tiferr(callback, stream => {
       stream.path.should.eql(target);

--- a/test/index.js
+++ b/test/index.js
@@ -994,10 +994,10 @@ describe('fs', () => {
     const result = await fs.ensurePath(join(target, 'foo.txt'));
     result.should.eql(join(target, 'foo-2.txt'));
 
-    const exist = await fs.exists(join(target, 'bar.txt'));
-    if (exist) await fs.unlink(join(target, 'bar.txt'));
+    // const exist = await fs.exists(join(target, 'bar.txt'));
+    // if (exist) await fs.unlink(join(target, 'bar.txt'));
 
-    await fs.rmdir(target);
+    fs.rmdir(target);
   });
 
   it('ensurePath() - file not exist', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@
 
 require('chai').use(require('chai-as-promised')).should();
 
-const { join, dirname } = require('path');
+const { join } = require('path');
 const Promise = require('bluebird');
 const fs = require('../lib/fs');
 const { tiferr } = require('iferr');

--- a/test/index.js
+++ b/test/index.js
@@ -1060,12 +1060,12 @@ describe('fs', () => {
       stream.on('close', resolve('success'));
     });
 
-    stream.end();
     const result = await streamPromise;
     result.should.eql('success');
 
     const exist = await fs.exists(target);
     if (exist) await fs.unlink(target);
+    stream.end();
   });
 
   it('ensureWriteStream() - callback', callback => {

--- a/test/index.js
+++ b/test/index.js
@@ -33,7 +33,10 @@ describe('fs', () => {
 
   before(() => fs.mkdirs(tmpDir));
 
-  after(() => fs.rmdir(tmpDir));
+  after(async () => {
+    const exist = await fs.exists(tmpDir);
+    if (exist) fs.rmdir(tmpDir);
+  });
 
   it('exists()', async () => {
     const exist = await fs.exists(tmpDir);

--- a/test/index.js
+++ b/test/index.js
@@ -33,7 +33,7 @@ describe('fs', () => {
 
   before(() => fs.mkdirs(tmpDir));
 
-  after(() => fs.rmdir(tmpDir));
+  after(async () => await fs.rmdir(tmpDir));
 
   it('exists()', async () => {
     const exist = await fs.exists(tmpDir);

--- a/test/index.js
+++ b/test/index.js
@@ -994,9 +994,6 @@ describe('fs', () => {
     const result = await fs.ensurePath(join(target, 'foo.txt'));
     result.should.eql(join(target, 'foo-2.txt'));
 
-    // const exist = await fs.exists(join(target, 'bar.txt'));
-    // if (exist) await fs.unlink(join(target, 'bar.txt'));
-
     fs.rmdir(target);
   });
 
@@ -1008,7 +1005,7 @@ describe('fs', () => {
 
   it('ensurePath() - callback', callback => {
     const target = join(tmpDir, 'test');
-    const filenames = ['foo.txt', 'foo-1.txt', 'foo-2.md', 'bar.txt'];
+    const filenames = ['foo.txt', 'foo-1.txt', 'foo-2.md'];
 
     Promise.map(filenames, path => fs.writeFile(join(target, path))).asCallback(tiferr(callback, () => {
       fs.ensurePath(join(target, 'foo.txt'), tiferr(callback, path => {

--- a/test/index.js
+++ b/test/index.js
@@ -1005,7 +1005,7 @@ describe('fs', () => {
 
   it('ensurePath() - callback', callback => {
     const target = join(tmpDir, 'test');
-    const filenames = ['foo.txt', 'foo-1.txt', 'foo-2.md'];
+    const filenames = ['foo.txt', 'foo-1.txt', 'foo-2.md', 'bar.txt'];
 
     Promise.map(filenames, path => fs.writeFile(join(target, path))).asCallback(tiferr(callback, () => {
       fs.ensurePath(join(target, 'foo.txt'), tiferr(callback, path => {
@@ -1064,7 +1064,8 @@ describe('fs', () => {
     const result = await streamPromise;
     result.should.eql('success');
 
-    await fs.unlink(target);
+    const exist = await fs.exists(target);
+    if (exist) await fs.unlink(target);
   });
 
   it('ensureWriteStream() - callback', callback => {

--- a/test/index.js
+++ b/test/index.js
@@ -35,7 +35,10 @@ describe('fs', () => {
 
   after(() => fs.rmdir(tmpDir));
 
-  it('exists()', () => fs.exists(tmpDir).should.become(true));
+  it('exists()', async () => {
+    const exist = await fs.exists(tmpDir);
+    exist.should.eql(true);
+  });
 
   it('exists() - callback', callback => {
     fs.exists(tmpDir, exist => {
@@ -49,17 +52,22 @@ describe('fs', () => {
     });
   });
 
-  it('exists() - path is required', () => {
-    fs.exists.should.to.throw('path is required!');
+  it('exists() - path is required', async () => {
+    try {
+      await fs.exists();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('mkdirs()', () => {
+  it('mkdirs()', async () => {
     const target = join(tmpDir, 'a', 'b', 'c');
 
-    return fs.mkdirs(target)
-      .then(() => fs.exists(target))
-      .should.become(true)
-      .then(() => fs.rmdir(join(tmpDir, 'a')));
+    await fs.mkdirs(target);
+    const exist = await fs.exists(target);
+    exist.should.eql(true);
+
+    await fs.rmdir(join(tmpDir, 'a'));
   });
 
   it('mkdirs() - callback', callback => {
@@ -73,32 +81,43 @@ describe('fs', () => {
     }));
   });
 
-  it('mkdirs() - path is required', () => {
-    fs.mkdirs.should.to.throw('path is required!');
+  it('mkdirs() - path is required', async () => {
+    try {
+      await fs.mkdirs();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('mkdirsSync()', () => {
+  it('mkdirsSync()', async () => {
     const target = join(tmpDir, 'a', 'b', 'c');
 
     fs.mkdirsSync(target);
 
-    return fs.exists(target)
-      .should.become(true)
-      .then(() => fs.rmdir(join(tmpDir, 'a')));
+    const exist = await fs.exists(target);
+    exist.should.eql(true);
+
+    await fs.rmdir(join(tmpDir, 'a'));
   });
 
   it('mkdirsSync() - path is required', () => {
-    fs.mkdirsSync.should.to.throw('path is required!');
+    try {
+      fs.mkdirsSync();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('writeFile()', () => {
+  it('writeFile()', async () => {
     const target = join(tmpDir, 'a', 'b', 'test.txt');
     const body = 'foo';
 
-    return fs.writeFile(target, body)
-      .then(() => fs.readFile(target))
-      .should.become(body)
-      .then(() => fs.rmdir(join(tmpDir, 'a')));
+    await fs.writeFile(target, body);
+    const result = await fs.readFile(target);
+
+    result.should.eql(body);
+
+    await fs.rmdir(join(tmpDir, 'a'));
   });
 
   it('writeFile() - callback', callback => {
@@ -113,35 +132,47 @@ describe('fs', () => {
     }));
   });
 
-  it('writeFile() - path is required', () => {
-    fs.writeFile.should.to.throw('path is required!');
+  it('writeFile() - path is required', async () => {
+    try {
+      await fs.writeFile();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('writeFileSync()', () => {
+  it('writeFileSync()', async () => {
     const target = join(tmpDir, 'a', 'b', 'test.txt');
     const body = 'foo';
 
     fs.writeFileSync(target, body);
 
-    return fs.readFile(target)
-      .should.become(body)
-      .then(() => fs.rmdir(join(tmpDir, 'a')));
+    const result = await fs.readFile(target);
+    result.should.eql(body);
+
+    await fs.rmdir(join(tmpDir, 'a'));
   });
 
   it('writeFileSync() - path is required', () => {
-    fs.writeFileSync.should.to.throw('path is required!');
+    try {
+      fs.writeFileSync();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('appendFile()', () => {
+  it('appendFile()', async () => {
     const target = join(tmpDir, 'a', 'b', 'test.txt');
     const body = 'foo';
     const body2 = 'bar';
 
-    return fs.writeFile(target, body)
-      .then(() => fs.appendFile(target, body2))
-      .then(() => fs.readFile(target))
-      .should.become(body + body2)
-      .then(() => fs.rmdir(join(tmpDir, 'a')));
+    await fs.writeFile(target, body);
+    await fs.appendFile(target, body2);
+
+    const result = await fs.readFile(target);
+
+    result.should.eql(body + body2);
+
+    await fs.rmdir(join(tmpDir, 'a'));
   });
 
   it('appendFile() - callback', callback => {
@@ -159,40 +190,51 @@ describe('fs', () => {
     }));
   });
 
-  it('appendFile() - path is required', () => {
-    fs.appendFile.should.to.throw('path is required!');
+  it('appendFile() - path is required', async () => {
+    try {
+      await fs.appendFile();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('appendFileSync()', () => {
+  it('appendFileSync()', async () => {
     const target = join(tmpDir, 'a', 'b', 'test.txt');
     const body = 'foo';
     const body2 = 'bar';
 
-    return fs.writeFile(target, body).then(() => {
-      fs.appendFileSync(target, body2);
-      return fs.readFile(target);
-    }).should.become(body + body2).then(() => {
-      return fs.rmdir(join(tmpDir, 'a'));
-    });
+    await fs.writeFile(target, body);
+    fs.appendFileSync(target, body2);
+
+    const result = await fs.readFile(target);
+    result.should.eql(body + body2);
+
+    await fs.rmdir(join(tmpDir, 'a'));
   });
 
   it('appendFileSync() - path is required', () => {
-    fs.appendFileSync.should.to.throw('path is required!');
+    try {
+      fs.appendFileSync();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('copyFile()', () => {
+  it('copyFile()', async () => {
     const src = join(tmpDir, 'test.txt');
     const dest = join(tmpDir, 'a', 'b', 'test.txt');
     const body = 'foo';
 
-    return fs.writeFile(src, body)
-      .then(() => fs.copyFile(src, dest))
-      .then(() => fs.readFile(dest))
-      .should.become(body)
-      .then(() => Promise.all([
-        fs.unlink(src),
-        fs.rmdir(join(tmpDir, 'a'))
-      ]));
+    await fs.writeFile(src, body);
+    await fs.copyFile(src, dest);
+
+    const result = await fs.readFile(dest);
+    result.should.eql(body);
+
+    await Promise.all([
+      fs.unlink(src),
+      fs.rmdir(join(tmpDir, 'a'))
+    ]);
   });
 
   it('copyFile() - callback', callback => {
@@ -214,15 +256,23 @@ describe('fs', () => {
     }));
   });
 
-  it('copyFile() - src is required', () => {
-    fs.copyFile.should.to.throw('src is required!');
+  it('copyFile() - src is required', async () => {
+    try {
+      await fs.copyFile();
+    } catch (err) {
+      err.message.should.eql('src is required!');
+    }
   });
 
-  it('copyFile() - dest is required', () => {
-    (() => fs.copyFile('123')).should.to.throw('dest is required!');
+  it('copyFile() - dest is required', async () => {
+    try {
+      await fs.copyFile('123');
+    } catch (err) {
+      err.message.should.eql('dest is required!');
+    }
   });
 
-  it('copyDir()', () => {
+  it('copyDir()', async () => {
     const src = join(tmpDir, 'a');
     const dest = join(tmpDir, 'b');
 
@@ -233,15 +283,18 @@ describe('fs', () => {
       join('folder', 'i.js')
     ];
 
-    return createDummyFolder(src)
-      .then(() => fs.copyDir(src, dest))
-      .then(files => files.should.have.members(filenames))
-      .thenReturn(filenames)
-      .map(path => fs.readFile(join(dest, path)))
-      .then(result => {
-        result.should.eql(['e', 'f', 'h', 'i']);
-        return Promise.all([fs.rmdir(src), fs.rmdir(dest)]);
-      });
+    await createDummyFolder(src);
+    const files = await fs.copyDir(src, dest);
+    files.should.eql(filenames);
+
+    const result = [];
+    for (const file of files) {
+      const output = await fs.readFile(join(dest, file));
+      result.push(output);
+    }
+    result.should.eql(['e', 'f', 'h', 'i']);
+
+    await Promise.all([fs.rmdir(src), fs.rmdir(dest)]);
   });
 
   it('copyDir() - callback', callback => {
@@ -268,15 +321,23 @@ describe('fs', () => {
     }));
   });
 
-  it('copyDir() - src is required', () => {
-    fs.copyDir.should.to.throw('src is required!');
+  it('copyDir() - src is required', async () => {
+    try {
+      await fs.copyDir();
+    } catch (err) {
+      err.message.should.eql('src is required!');
+    }
   });
 
-  it('copyDir() - dest is required', () => {
-    (() => fs.copyDir('123')).should.to.throw('dest is required!');
+  it('copyDir() - dest is required', async () => {
+    try {
+      await fs.copyDir('123');
+    } catch (err) {
+      err.message.should.eql('dest is required!');
+    }
   });
 
-  it('copyDir() - ignoreHidden off', () => {
+  it('copyDir() - ignoreHidden off', async () => {
     const src = join(tmpDir, 'a');
     const dest = join(tmpDir, 'b');
 
@@ -292,42 +353,54 @@ describe('fs', () => {
       join('folder', '.j')
     ];
 
-    return createDummyFolder(src)
-      .then(() => fs.copyDir(src, dest, {ignoreHidden: false}))
-      .then(files => files.should.have.members(filenames))
-      .return(filenames)
-      .map(path => fs.readFile(join(dest, path)))
-      .should.become(['a', 'b', 'd', 'e', 'f', 'g', 'h', 'i', 'j'])
-      .then(() => Promise.all([fs.rmdir(src), fs.rmdir(dest)]));
+    await createDummyFolder(src);
+    const files = await fs.copyDir(src, dest, { ignoreHidden: false });
+    files.should.have.members(filenames);
+
+    const result = [];
+    for (const file of files) {
+      const output = await fs.readFile(join(dest, file));
+      result.push(output);
+    }
+    result.should.have.members(['a', 'b', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
+
+    await Promise.all([fs.rmdir(src), fs.rmdir(dest)]);
   });
 
-  it('copyDir() - ignorePattern', () => {
+  it('copyDir() - ignorePattern', async () => {
     const src = join(tmpDir, 'a');
     const dest = join(tmpDir, 'b');
 
     const filenames = ['e.txt', join('folder', 'h.txt')];
 
-    return createDummyFolder(src)
-      .then(() => fs.copyDir(src, dest, {ignorePattern: /\.js/}))
-      .then(files => files.should.have.members(filenames))
-      .return(filenames)
-      .map(path => fs.readFile(join(dest, path)))
-      .should.become(['e', 'h'])
-      .then(() => Promise.all([fs.rmdir(src), fs.rmdir(dest)]));
+    await createDummyFolder(src);
+    const files = await fs.copyDir(src, dest, { ignorePattern: /\.js/ });
+    files.should.eql(filenames);
+
+    const result = [];
+    for (const file of files) {
+      const output = await fs.readFile(join(dest, file));
+      result.push(output);
+    }
+    result.should.eql(['e', 'h']);
+
+    await Promise.all([fs.rmdir(src), fs.rmdir(dest)]);
   });
 
-  it('listDir()', () => {
+  it('listDir()', async () => {
+    const expected = [
+      'e.txt',
+      'f.js',
+      join('folder', 'h.txt'),
+      join('folder', 'i.js')
+    ];
     const target = join(tmpDir, 'test');
 
-    return createDummyFolder(target)
-      .then(() => fs.listDir(target))
-      .should.eventually.have.members([
-        'e.txt',
-        'f.js',
-        join('folder', 'h.txt'),
-        join('folder', 'i.js')
-      ])
-      .then(() => fs.rmdir(target));
+    await createDummyFolder(target);
+    const dir = await fs.listDir(target);
+    dir.should.eql(expected);
+
+    await fs.rmdir(target);
   });
 
   it('listDir() - callback', callback => {
@@ -348,11 +421,15 @@ describe('fs', () => {
     }));
   });
 
-  it('listDir() - path is required', () => {
-    fs.listDir.should.to.throw('path is required!');
+  it('listDir() - path is required', async () => {
+    try {
+      await fs.listDir();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('listDir() - ignoreHidden off', () => {
+  it('listDir() - ignoreHidden off', async () => {
     const target = join(tmpDir, 'test');
 
     const filenames = [
@@ -367,22 +444,24 @@ describe('fs', () => {
       join('folder', '.j')
     ];
 
-    return createDummyFolder(target)
-      .then(() => fs.listDir(target, {ignoreHidden: false}))
-      .should.eventually.have.members(filenames)
-      .then(() => fs.rmdir(target));
+    await createDummyFolder(target);
+    const dir = await fs.listDir(target, { ignoreHidden: false });
+    dir.should.have.members(filenames);
+
+    await fs.rmdir(target);
   });
 
-  it('listDir() - ignorePattern', () => {
+  it('listDir() - ignorePattern', async () => {
     const target = join(tmpDir, 'test');
 
-    return createDummyFolder(target)
-      .then(() => fs.listDir(target, {ignorePattern: /\.js/}))
-      .should.eventually.have.members(['e.txt', join('folder', 'h.txt')])
-      .then(() => fs.rmdir(target));
+    await createDummyFolder(target);
+    const dir = await fs.listDir(target, { ignorePattern: /\.js/ });
+    dir.should.eql(['e.txt', join('folder', 'h.txt')]);
+
+    await fs.rmdir(target);
   });
 
-  it('listDirSync()', () => {
+  it('listDirSync()', async () => {
     const target = join(tmpDir, 'test');
 
     const filenames = [
@@ -392,18 +471,22 @@ describe('fs', () => {
       join('folder', 'i.js')
     ];
 
-    return createDummyFolder(target).then(() => {
-      const files = fs.listDirSync(target);
-      files.should.have.members(filenames);
-      return fs.rmdir(target);
-    });
+    await createDummyFolder(target);
+    const files = fs.listDirSync(target);
+    files.should.eql(filenames);
+
+    await fs.rmdir(target);
   });
 
   it('listDirSync() - path is required', () => {
-    fs.listDirSync.should.to.throw('path is required!');
+    try {
+      fs.listDirSync();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('listDirSync() - ignoreHidden off', () => {
+  it('listDirSync() - ignoreHidden off', async () => {
     const target = join(tmpDir, 'test');
 
     const filenames = [
@@ -418,31 +501,32 @@ describe('fs', () => {
       join('folder', '.j')
     ];
 
-    return createDummyFolder(target).then(() => {
-      const files = fs.listDirSync(target, {ignoreHidden: false});
-      files.should.have.members(filenames);
-      return fs.rmdir(target);
-    });
+    await createDummyFolder(target);
+    const files = fs.listDirSync(target, { ignoreHidden: false });
+    files.should.have.members(filenames);
+
+    await fs.rmdir(target);
   });
 
-  it('listDirSync() - ignorePattern', () => {
+  it('listDirSync() - ignorePattern', async () => {
     const target = join(tmpDir, 'test');
 
-    return createDummyFolder(target).then(() => {
-      const files = fs.listDirSync(target, {ignorePattern: /\.js/});
-      files.should.have.members(['e.txt', join('folder', 'h.txt')]);
-      return fs.rmdir(target);
-    });
+    await createDummyFolder(target);
+    const files = fs.listDirSync(target, {ignorePattern: /\.js/});
+    files.should.eql(['e.txt', join('folder', 'h.txt')]);
+
+    await fs.rmdir(target);
   });
 
-  it('readFile()', () => {
+  it('readFile()', async () => {
     const target = join(tmpDir, 'test.txt');
     const body = 'test';
 
-    return fs.writeFile(target, body)
-      .then(() => fs.readFile(target))
-      .should.become(body)
-      .then(() => fs.unlink(target));
+    await fs.writeFile(target, body);
+    const result = await fs.readFile(target);
+    result.should.eql(body);
+
+    await fs.unlink(target);
   });
 
   it('readFile() - callback', callback => {
@@ -457,76 +541,91 @@ describe('fs', () => {
     }));
   });
 
-  it('readFile() - path is required', () => {
-    fs.readFile.should.to.throw('path is required!');
+  it('readFile() - path is required', async () => {
+    try {
+      await fs.readFile();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('readFile() - escape BOM', () => {
+  it('readFile() - escape BOM', async () => {
     const target = join(tmpDir, 'test.txt');
     const body = '\ufefffoo';
 
-    return fs.writeFile(target, body)
-      .then(() => fs.readFile(target))
-      .should.become('foo')
-      .then(() => fs.unlink(target));
+    await fs.writeFile(target, body);
+    const result = await fs.readFile(target);
+
+    result.should.eql('foo');
+
+    await fs.unlink(target);
   });
 
-  it('readFile() - escape Windows line ending', () => {
+  it('readFile() - escape Windows line ending', async () => {
     const target = join(tmpDir, 'test.txt');
     const body = 'foo\r\nbar';
 
-    return fs.writeFile(target, body)
-      .then(() => fs.readFile(target))
-      .should.become('foo\nbar')
-      .then(() => fs.unlink(target));
+    await fs.writeFile(target, body);
+    const result = await fs.readFile(target);
+    result.should.eql('foo\nbar');
+
+    await fs.unlink(target);
   });
 
-  it('readFileSync()', () => {
+  it('readFileSync()', async () => {
     const target = join(tmpDir, 'test.txt');
     const body = 'test';
 
-    return fs.writeFile(target, body).then(() => {
-      fs.readFileSync(target).should.eql(body);
-      return fs.unlink(target);
-    });
+    await fs.writeFile(target, body);
+    const result = fs.readFileSync(target);
+    result.should.eql(body);
+
+    await fs.unlink(target);
   });
 
   it('readFileSync() - path is required', () => {
-    fs.readFileSync.should.to.throw('path is required!');
+    try {
+      fs.readFileSync();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('readFileSync() - escape BOM', () => {
+  it('readFileSync() - escape BOM', async () => {
     const target = join(tmpDir, 'test.txt');
     const body = '\ufefffoo';
 
-    return fs.writeFile(target, body).then(() => {
-      fs.readFileSync(target).should.eql('foo');
-      return fs.unlink(target);
-    });
+    await fs.writeFile(target, body);
+    const result = fs.readFileSync(target);
+    result.should.eql('foo');
+
+    await fs.unlink(target);
   });
 
-  it('readFileSync() - escape Windows line ending', () => {
+  it('readFileSync() - escape Windows line ending', async () => {
     const target = join(tmpDir, 'test.txt');
     const body = 'foo\r\nbar';
 
-    return fs.writeFile(target, body).then(() => {
-      fs.readFileSync(target).should.eql('foo\nbar');
-      return fs.unlink(target);
-    });
+    await fs.writeFile(target, body);
+    const result = fs.readFileSync(target);
+    result.should.eql('foo\nbar');
+
+    await fs.unlink(target);
   });
 
-  it('unlink()', () => {
+  it('unlink()', async () => {
     const target = join(tmpDir, 'test-unlink');
 
-    return fs.writeFile(target, '')
-      .then(() => fs.exists(target))
-      .should.become(true)
-      .then(() => fs.unlink(target))
-      .then(() => fs.exists(target))
-      .should.become(false);
+    await fs.writeFile(target, '');
+    let exist = await fs.exists(target);
+    exist.should.eql(true);
+
+    await fs.unlink(target);
+    exist = await fs.exists(target);
+    exist.should.eql(false);
   });
 
-  it('emptyDir()', () => {
+  it('emptyDir()', async () => {
     const target = join(tmpDir, 'test');
 
     const checkExistsMap = {
@@ -541,20 +640,22 @@ describe('fs', () => {
       [join('folder', '.j')]: true
     };
 
-    return createDummyFolder(target)
-      .then(() => fs.emptyDir(target))
-      .then(files => {
-        files.should.have.members([
-          'e.txt',
-          'f.js',
-          join('folder', 'h.txt'),
-          join('folder', 'i.js')
-        ]);
+    await createDummyFolder(target);
+    const files = await fs.emptyDir(target);
+    files.should.eql([
+      'e.txt',
+      'f.js',
+      join('folder', 'h.txt'),
+      join('folder', 'i.js')
+    ]);
 
-        return Object.keys(checkExistsMap);
-      })
-      .map(path => fs.exists(join(target, path)).should.become(checkExistsMap[path]))
-      .then(() => fs.rmdir(target));
+    const paths = Object.keys(checkExistsMap);
+    for (const path of paths) {
+      const exist = await fs.exists(join(target, path));
+      exist.should.eql(checkExistsMap[path]);
+    }
+
+    await fs.rmdir(target);
   });
 
   it('emptyDir() - callback', callback => {
@@ -590,11 +691,15 @@ describe('fs', () => {
     }));
   });
 
-  it('emptyDir() - path is required', () => {
-    fs.emptyDir.should.to.throw('path is required!');
+  it('emptyDir() - path is required', async () => {
+    try {
+      await fs.emptyDir();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('emptyDir() - ignoreHidden off', () => {
+  it('emptyDir() - ignoreHidden off', async () => {
     const target = join(tmpDir, 'test');
 
     const filenames = [
@@ -609,15 +714,19 @@ describe('fs', () => {
       join('folder', '.j')
     ];
 
-    return createDummyFolder(target)
-      .then(() => fs.emptyDir(target, {ignoreHidden: false}))
-      .then(files => files.should.have.members(filenames))
-      .return(filenames)
-      .map(path => fs.exists(join(target, path)).should.become(false))
-      .then(() => fs.rmdir(target));
+    await createDummyFolder(target);
+    const files = await fs.emptyDir(target, { ignoreHidden: false });
+    files.should.have.members(filenames);
+
+    for (const file of files) {
+      const exist = await fs.exists(join(target, file));
+      exist.should.eql(false);
+    }
+
+    await fs.rmdir(target);
   });
 
-  it('emptyDir() - ignorePattern', () => {
+  it('emptyDir() - ignorePattern', async () => {
     const target = join(tmpDir, 'test');
 
     const checkExistsMap = {
@@ -632,15 +741,20 @@ describe('fs', () => {
       [join('folder', '.j')]: true
     };
 
-    return createDummyFolder(target)
-      .then(() => fs.emptyDir(target, {ignorePattern: /\.js/}))
-      .then(files => files.should.have.members(['e.txt', join('folder', 'h.txt')]))
-      .return(Object.keys(checkExistsMap))
-      .map(path => fs.exists(join(target, path)).should.become(checkExistsMap[path]))
-      .then(() => fs.rmdir(target));
+    await createDummyFolder(target);
+    const files = await fs.emptyDir(target, { ignorePattern: /\.js/ });
+    files.should.eql(['e.txt', join('folder', 'h.txt')]);
+
+    const paths = Object.keys(checkExistsMap);
+    for (const path of paths) {
+      const exist = await fs.exists(join(target, path));
+      exist.should.eql(checkExistsMap[path]);
+    }
+
+    await fs.rmdir(target);
   });
 
-  it('emptyDir() - exclude', () => {
+  it('emptyDir() - exclude', async () => {
     const target = join(tmpDir, 'test');
 
     const checkExistsMap = {
@@ -655,15 +769,20 @@ describe('fs', () => {
       [join('folder', '.j')]: true
     };
 
-    return createDummyFolder(target)
-      .then(() => fs.emptyDir(target, {exclude: ['e.txt', join('folder', 'i.js')]}))
-      .then(files => files.should.have.members(['f.js', join('folder', 'h.txt')]))
-      .return(Object.keys(checkExistsMap))
-      .map(path => fs.exists(join(target, path)).should.become(checkExistsMap[path]))
-      .then(() => fs.rmdir(target));
+    await createDummyFolder(target);
+    const files = await fs.emptyDir(target, { exclude: ['e.txt', join('folder', 'i.js')] });
+    files.should.eql(['f.js', join('folder', 'h.txt')]);
+
+    const paths = Object.keys(checkExistsMap);
+    for (const path of paths) {
+      const exist = await fs.exists(join(target, path));
+      exist.should.eql(checkExistsMap[path]);
+    }
+
+    await fs.rmdir(target);
   });
 
-  it('emptyDirSync()', () => {
+  it('emptyDirSync()', async () => {
     const target = join(tmpDir, 'test');
 
     const checkExistsMap = {
@@ -678,27 +797,33 @@ describe('fs', () => {
       [join('folder', '.j')]: true
     };
 
-    return createDummyFolder(target)
-      .then(() => {
-        const files = fs.emptyDirSync(target);
-        files.should.have.members([
-          'e.txt',
-          'f.js',
-          join('folder', 'h.txt'),
-          join('folder', 'i.js')
-        ]);
+    await createDummyFolder(target);
+    const files = fs.emptyDirSync(target);
+    files.should.eql([
+      'e.txt',
+      'f.js',
+      join('folder', 'h.txt'),
+      join('folder', 'i.js')
+    ]);
 
-        return Object.keys(checkExistsMap);
-      })
-      .map(path => fs.exists(join(target, path)).should.become(checkExistsMap[path]))
-      .then(() => fs.rmdir(target));
+    const paths = Object.keys(checkExistsMap);
+    for (const path of paths) {
+      const exist = await fs.exists(join(target, path));
+      exist.should.eql(checkExistsMap[path]);
+    }
+
+    await fs.rmdir(target);
   });
 
   it('emptyDirSync() - path is required', () => {
-    fs.emptyDirSync.should.to.throw('path is required!');
+    try {
+      fs.emptyDirSync();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('emptyDirSync() - ignoreHidden off', () => {
+  it('emptyDirSync() - ignoreHidden off', async () => {
     const target = join(tmpDir, 'test');
 
     const filenames = [
@@ -713,17 +838,19 @@ describe('fs', () => {
       join('folder', '.j')
     ];
 
-    return createDummyFolder(target)
-      .then(() => {
-        const files = fs.emptyDirSync(target, {ignoreHidden: false});
-        files.should.have.members(filenames);
-        return filenames;
-      })
-      .map(path => fs.exists(join(target, path)).should.become(false))
-      .then(() => fs.rmdir(target));
+    await createDummyFolder(target);
+    const files = fs.emptyDirSync(target, { ignoreHidden: false });
+    files.should.have.members(filenames);
+
+    for (const file of files) {
+      const exist = await fs.exists(join(target, file));
+      exist.should.eql(false);
+    }
+
+    await fs.rmdir(target);
   });
 
-  it('emptyDirSync() - ignorePattern', () => {
+  it('emptyDirSync() - ignorePattern', async () => {
     const target = join(tmpDir, 'test');
 
     const checkExistsMap = {
@@ -738,18 +865,20 @@ describe('fs', () => {
       [join('folder', '.j')]: true
     };
 
-    return createDummyFolder(target)
-      .then(() => {
-        const files = fs.emptyDirSync(target, {ignorePattern: /\.js/});
-        files.should.have.members(['e.txt', join('folder', 'h.txt')]);
+    await createDummyFolder(target);
+    const files = fs.emptyDirSync(target, { ignorePattern: /\.js/ });
+    files.should.eql(['e.txt', join('folder', 'h.txt')]);
 
-        return Object.keys(checkExistsMap);
-      })
-      .map(path => fs.exists(join(target, path)).should.become(checkExistsMap[path]))
-      .then(() => fs.rmdir(target));
+    const paths = Object.keys(checkExistsMap);
+    for (const path of paths) {
+      const exist = await fs.exists(join(target, path));
+      exist.should.eql(checkExistsMap[path]);
+    }
+
+    await fs.rmdir(target);
   });
 
-  it('emptyDirSync() - exclude', () => {
+  it('emptyDirSync() - exclude', async () => {
     const target = join(tmpDir, 'test');
 
     const checkExistsMap = {
@@ -764,24 +893,26 @@ describe('fs', () => {
       [join('folder', '.j')]: true
     };
 
-    return createDummyFolder(target)
-      .then(() => {
-        const files = fs.emptyDirSync(target, {exclude: ['e.txt', join('folder', 'i.js')]});
-        files.should.have.members(['f.js', join('folder', 'h.txt')]);
+    await createDummyFolder(target);
+    const files = fs.emptyDirSync(target, { exclude: ['e.txt', join('folder', 'i.js')] });
+    files.should.eql(['f.js', join('folder', 'h.txt')]);
 
-        return Object.keys(checkExistsMap);
-      })
-      .map(path => fs.exists(join(target, path)).should.become(checkExistsMap[path]))
-      .then(() => fs.rmdir(target));
+    const paths = Object.keys(checkExistsMap);
+    for (const path of paths) {
+      const exist = await fs.exists(join(target, path));
+      exist.should.eql(checkExistsMap[path]);
+    }
+
+    await fs.rmdir(target);
   });
 
-  it('rmdir()', () => {
+  it('rmdir()', async () => {
     const target = join(tmpDir, 'test');
 
-    return createDummyFolder(target)
-      .then(() => fs.rmdir(target))
-      .then(() => fs.exists(target))
-      .should.become(false);
+    await createDummyFolder(target);
+    await fs.rmdir(target);
+    const exist = await fs.exists(target);
+    exist.should.eql(false);
   });
 
   it('rmdir() - callback', callback => {
@@ -802,63 +933,74 @@ describe('fs', () => {
     }));
   });
 
-  it('rmdir() - path is required', () => {
-    fs.rmdir.should.to.throw('path is required!');
+  it('rmdir() - path is required', async () => {
+    try {
+      await fs.rmdir();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('rmdirSync()', () => {
+  it('rmdirSync()', async () => {
     const target = join(tmpDir, 'test');
 
-    return createDummyFolder(target).then(() => {
-      fs.rmdirSync(target);
-      return fs.exists(target);
-    }).should.become(false);
+    await createDummyFolder(target);
+    fs.rmdirSync(target);
+    const exist = await fs.exists(target);
+    exist.should.eql(false);
   });
 
   it('rmdirSync() - path is required', () => {
-    fs.rmdirSync.should.to.throw('path is required!');
+    try {
+      fs.rmdirSync();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('watch()', () => {
-    let watcher;
+  it('watch()', async () => {
     const target = join(tmpDir, 'test.txt');
 
     const testerWrap = _watcher => new Promise((resolve, reject) => {
       _watcher.on('add', resolve).on('error', reject);
     });
 
-    return fs.watch(tmpDir).then(watcher_ => {
-      watcher = watcher_;
+    const watcher = await fs.watch(tmpDir);
+    const result = await Promise.all([
+      testerWrap(watcher),
+      fs.writeFile(target, 'test')
+    ]);
+    result[0].should.eql(target);
 
-      return Promise.all([
-        testerWrap(watcher).should.become(target),
-        fs.writeFile(target, 'test')
-      ]);
-    }).finally(() => {
-      if (watcher) {
-        watcher.close();
-      }
-      return fs.unlink(target);
-    });
+    if (watcher) {
+      watcher.close();
+    }
+    await fs.unlink(target);
   });
 
-  it('watch() - path is required', () => {
-    fs.watch.should.to.throw('path is required!');
+  it('watch() - path is required', async () => {
+    try {
+      await fs.watch();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('ensurePath() - file exists', () => {
+  it('ensurePath() - file exists', async () => {
     const target = join(tmpDir, 'test');
     const filenames = ['foo.txt', 'foo-1.txt', 'foo-2.md', 'bar.txt'];
 
-    return Promise.map(filenames, path => fs.writeFile(join(target, path)))
-      .then(() => fs.ensurePath(join(target, 'foo.txt')))
-      .should.become(join(target, 'foo-2.txt'))
-      .then(() => fs.rmdir(target));
+    await Promise.map(filenames, path => fs.writeFile(join(target, path)));
+    const result = await fs.ensurePath(join(target, 'foo.txt'));
+    result.should.eql(join(target, 'foo-2.txt'));
+
+    await fs.rmdir(target);
   });
 
-  it('ensurePath() - file not exist', () => {
+  it('ensurePath() - file not exist', async () => {
     const target = join(tmpDir, 'foo.txt');
-    return fs.ensurePath(target).should.become(target);
+    const result = await fs.ensurePath(target);
+    result.should.eql(target);
   });
 
   it('ensurePath() - callback', callback => {
@@ -873,20 +1015,23 @@ describe('fs', () => {
     }));
   });
 
-  it('ensurePath() - path is required', () => {
-    fs.ensurePath.should.to.throw('path is required!');
+  it('ensurePath() - path is required', async () => {
+    try {
+      await fs.ensurePath();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('ensurePathSync() - file exists', () => {
+  it('ensurePathSync() - file exists', async () => {
     const target = join(tmpDir, 'test');
     const filenames = ['foo.txt', 'foo-1.txt', 'foo-2.md', 'bar.txt'];
 
-    return Promise.map(filenames, path => fs.writeFile(join(target, path))).then(() => {
-      const path = fs.ensurePathSync(join(target, 'foo.txt'));
-      path.should.eql(join(target, 'foo-2.txt'));
+    await Promise.map(filenames, path => fs.writeFile(join(target, path)));
+    const path = fs.ensurePathSync(join(target, 'foo.txt'));
+    path.should.eql(join(target, 'foo-2.txt'));
 
-      return fs.rmdir(target);
-    });
+    await fs.rmdir(target);
   });
 
   it('ensurePathSync() - file not exist', () => {
@@ -897,23 +1042,29 @@ describe('fs', () => {
   });
 
   it('ensurePathSync() - path is required', () => {
-    fs.ensurePathSync.should.to.throw('path is required!');
+    try {
+      fs.ensurePathSync();
+    } catch (err) {
+      err.message.should.eql('path is required!');
+    }
   });
 
-  it('ensureWriteStream()', () => {
+  it('ensureWriteStream()', async () => {
     const target = join(tmpDir, 'foo', 'bar.txt');
 
-    return fs.ensureWriteStream(target).then(stream => {
-      stream.path.should.eql(target);
+    const stream = await fs.ensureWriteStream(target);
+    stream.path.should.eql(target);
 
-      const streamPromise = new Promise((resolve, reject) => {
-        stream.on('error', reject);
-        stream.on('close', resolve);
-      });
+    const streamPromise = new Promise((resolve, reject) => {
+      stream.on('error', reject);
+      stream.on('close', resolve('success'));
+    });
 
-      stream.end();
-      return streamPromise;
-    }).then(() => fs.unlink(target));
+    stream.end();
+    const result = await streamPromise;
+    result.should.eql('success');
+
+    await fs.unlink(target);
   });
 
   it('ensureWriteStream() - callback', callback => {

--- a/test/index.js
+++ b/test/index.js
@@ -960,7 +960,7 @@ describe('fs', () => {
 
   it('watch()', () => {
     let watcher;
-    const target = join(tmpDir, 'test.txt');
+    const target = join(tmpDir, 'testa.txt');
 
     const testerWrap = _watcher => new Promise((resolve, reject) => {
       _watcher.on('add', resolve).on('error', reject);


### PR DESCRIPTION
I intend to drop bluebird and chai-as-promised.

bluebird is only used to promisify the fs API, which can be achieved using the [native promisfy](https://nodejs.org/docs/latest-v8.x/api/util.html#util_util_promisify_original) (supported in Node 8+).