### PR TITLE
fs.mkdir(sync) supports recursive option

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -36,54 +36,26 @@ function existsSync(path) {
   return true;
 }
 
-async function _mkdirs(path) {
-  const parent = dirname(path);
-
-  try {
-    await fsPromises.access(path);
-  } catch (err) {
-    if (err.code !== 'ENOENT') throw err;
-    await _mkdirs(parent);
-  }
-
-  try {
-    await fsPromises.mkdir(path);
-  } catch (err) {
-    if (err.code !== 'EEXIST') throw err;
-  }
-}
-
 function mkdirs(path, callback) {
   if (!path) throw new TypeError('path is required!');
 
-  return Promise.resolve(_mkdirs(path)).asCallback(callback);
+  return Promise.resolve(fsPromises.mkdir(path, { recursive: true })).asCallback(callback);
 }
 
 function mkdirsSync(path) {
   if (!path) throw new TypeError('path is required!');
 
-  const parent = dirname(path);
-
-  if (!fs.existsSync(parent)) mkdirsSync(parent);
-  fs.mkdirSync(path);
+  fs.mkdirSync(path, { recursive: true });
 }
 
 function checkParent(path) {
-  return Promise.resolve(_mkdirs(dirname(path)));
+  return Promise.resolve(fsPromises.mkdir(dirname(path), { recursive: true }));
 }
 
 function checkParentSync(path) {
   if (!path) throw new TypeError('path is required!');
 
-  const parent = dirname(path);
-
-  if (fs.existsSync(parent)) return;
-
-  try {
-    mkdirsSync(parent);
-  } catch (err) {
-    if (err.code !== 'EEXIST') throw err;
-  }
+  fs.mkdirSync(dirname(path), { recursive: true });
 }
 
 function writeFile(path, data, options, callback) {

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -52,12 +52,6 @@ function checkParent(path) {
   return Promise.resolve(fsPromises.mkdir(dirname(path), { recursive: true }));
 }
 
-function checkParentSync(path) {
-  if (!path) throw new TypeError('path is required!');
-
-  fs.mkdirSync(dirname(path), { recursive: true });
-}
-
 function writeFile(path, data, options, callback) {
   if (!path) throw new TypeError('path is required!');
 
@@ -72,7 +66,7 @@ function writeFile(path, data, options, callback) {
 function writeFileSync(path, data, options) {
   if (!path) throw new TypeError('path is required!');
 
-  checkParentSync(path);
+  fs.mkdirSync(dirname(path), { recursive: true });
   fs.writeFileSync(path, data, options);
 }
 
@@ -90,7 +84,7 @@ function appendFile(path, data, options, callback) {
 function appendFileSync(path, data, options) {
   if (!path) throw new TypeError('path is required!');
 
-  checkParentSync(path);
+  fs.mkdirSync(dirname(path), { recursive: true });
   fs.appendFileSync(path, data, options);
 }
 
@@ -438,7 +432,7 @@ function ensureWriteStream(path, options, callback) {
 function ensureWriteStreamSync(path, options) {
   if (!path) throw new TypeError('path is required!');
 
-  checkParentSync(path);
+  fs.mkdirSync(dirname(path), { recursive: true });
   return fs.createWriteStream(path, options);
 }
 


### PR DESCRIPTION
[fs.mkdir(Sync) has implemented an option to execute recursively when the node version is v10.12.0 or later.](https://nodejs.org/api/fs.html#fs_fs_mkdir_path_options_callback)
This eliminates the need for recursion in hexo-fs.