### PR TITLE
refactor: es6 syntax

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -139,13 +139,13 @@ function trueFn() {
 function ignoreHiddenFiles(ignore) {
   if (!ignore) return trueFn;
 
-  return item => item.name[0] !== '.';
+  return ({ name }) => !name.startsWith('.');
 }
 
 function ignoreFilesRegex(regex) {
   if (!regex) return trueFn;
 
-  return item => !regex.test(item.name);
+  return ({ name }) => !regex.test(name);
 }
 
 function ignoreExcludeFiles(arr, parent) {
@@ -153,7 +153,7 @@ function ignoreExcludeFiles(arr, parent) {
 
   const set = new Set(arr);
 
-  return item => !set.has(join(parent, item.name));
+  return ({ name }) => !set.has(join(parent, name));
 }
 
 function reduceFiles(result, item) {
@@ -167,14 +167,14 @@ function reduceFiles(result, item) {
 
 async function _readAndFilterDir(path, options) {
   const { ignoreHidden = true, ignorePattern } = options;
-  return (await fsPromises.readdir(path, Object.assign(options, { withFileTypes: true })))
+  return (await fsPromises.readdir(path, { ...options, withFileTypes: true }))
     .filter(ignoreHiddenFiles(ignoreHidden))
     .filter(ignoreFilesRegex(ignorePattern));
 }
 
 function _readAndFilterDirSync(path, options) {
   const { ignoreHidden = true, ignorePattern } = options;
-  return fs.readdirSync(path, Object.assign(options, { withFileTypes: true }))
+  return fs.readdirSync(path, { ...options, withFileTypes: true })
     .filter(ignoreHiddenFiles(ignoreHidden))
     .filter(ignoreFilesRegex(ignorePattern));
 }


### PR DESCRIPTION
- destructuring syntax
- spread syntax as a replacement of `Object.assign`
- `String#startsWith()`