### PR TITLE
fix: compatible with Node.js 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ node_js:
   - "10"
   - "12"
   - "13"
+  - "14"
 
 script:
   - npm run eslint

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -89,6 +89,8 @@ function checkParentSync(path) {
 function writeFile(path, data, options, callback) {
   if (!path) throw new TypeError('path is required!');
 
+  if (!data) data = '';
+
   if (!callback && typeof options === 'function') {
     callback = options;
     options = {};
@@ -127,6 +129,7 @@ function copyFile(src, dest, flags, callback) {
   if (!dest) throw new TypeError('dest is required!');
   if (typeof flags === 'function') {
     callback = flags;
+    flags = undefined;
   }
 
   return checkParent(dest).then(() => fsPromises.copyFile(src, dest, flags)).asCallback(callback);
@@ -190,7 +193,7 @@ async function _copyDir(src, dest, options, parent) {
       return _copyDir(childSrc, childDest, options, currentPath);
     }
 
-    return copyFile(childSrc, childDest, options).thenReturn(currentPath);
+    return copyFile(childSrc, childDest).thenReturn(currentPath);
   }), reduceFiles, []);
 }
 


### PR DESCRIPTION
This PR makes some fixes to make `hexo-fs` compatible with Node.js 14.

Related issue: https://github.com/hexojs/hexo/issues/4260 https://github.com/hexojs/hexo/issues/4263