### PR TITLE
ci(appveyor): stop updating npm

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,6 @@ matrix:
 # Install scripts. (runs after repo cloning)
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install -g npm
   - npm install
 
 cache:


### PR DESCRIPTION
`npm install -g npm` keeps failing on Node 14. Updating npm is not necessary since Appveyor already uses latest Node versions which bundle the latest npm.

This also make it consistent with Travis, which never had this operation.