### PR TITLE
chore: update the package.json for publishing with typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "files": [
     "dist/**"
   ],
+  "types": "./dist/fs.d.ts",
   "repository": "hexojs/hexo-fs",
   "homepage": "https://hexo.io/",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -2,18 +2,17 @@
   "name": "hexo-fs",
   "version": "3.1.0",
   "description": "File system module for Hexo.",
-  "main": "lib/fs.js",
+  "main": "./dist/fs.js",
   "scripts": {
+    "prepublish ": "npm run clean && npm run build",
     "build": "tsc -b",
+    "clean": "tsc -b --clean",
     "eslint": "eslint .",
     "test": "mocha test/index.js --require ts-node/register",
     "test-cov": "nyc --reporter=lcovonly npm run test"
   },
-  "directories": {
-    "lib": "./lib"
-  },
   "files": [
-    "lib/fs.js"
+    "dist/**"
   ],
   "repository": "hexojs/hexo-fs",
   "homepage": "https://hexo.io/",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "es6",
     "sourceMap": true,
     "outDir": "dist",
+    "declaration": true,
     "esModuleInterop": true,
     "types": [
       "node"


### PR DESCRIPTION
I'm going to publish a new version. It will be include to replace TypeScript [#66](https://github.com/hexojs/hexo-fs/pull/66).
But, the current `package.json` settings are not enough for publishing with TypeScript.

This PR is a scaffold for publishing TypeScript.
Thank you :)