### PR TITLE
Pass flags to copyFile

### DIFF
--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -152,7 +152,7 @@ async function _copyDirWalker(
       return _copyDirWalker(childSrc, childDest, results, currentPath, options);
     }
     results.push(currentPath);
-    return copyFile(childSrc, childDest);
+    return copyFile(childSrc, childDest, 0);
   });
 }
 


### PR DESCRIPTION
This prevents an error when running `hexo deploy` using the Heroku deployer, and gets us one step closer to being able to deploy Hexo blogs to Heroku:

`err: TypeError [ERR_INVALID_ARG_TYPE]: The "mode" argument must be integer. Received an instance of Object`