### PR TITLE
release: 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-fs",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "File system module for Hexo.",
   "main": "./dist/fs.js",
   "scripts": {


### PR DESCRIPTION
### Breaking Changes

- https://github.com/hexojs/hexo-fs/pull/102

### Notable Changes

- Migrate TypeScript

### Note

If we release `4.0.0`, we also have to start to drop support node 12 for other packages.