### PR TITLE
fix: missing types

### DIFF
--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -524,7 +524,7 @@ export const read = BlueBirdPromise.promisify(fs.read);
 export const readSync = fs.readSync;
 
 // readdir
-export const readdir = BlueBirdPromise.promisify(fs.readdir);
+export const readdir = BlueBirdPromise.promisify<string[], fs.PathLike>(fs.readdir);
 export const readdirSync = fs.readdirSync;
 
 // readlink
@@ -536,11 +536,11 @@ export const realpath = BlueBirdPromise.promisify(fs.realpath);
 export const realpathSync = fs.realpathSync;
 
 // rename
-export const rename = BlueBirdPromise.promisify(fs.rename);
+export const rename = BlueBirdPromise.promisify<void, fs.PathLike, fs.PathLike>(fs.rename);
 export const renameSync = fs.renameSync;
 
 // stat
-export const stat = BlueBirdPromise.promisify(fs.stat);
+export const stat = BlueBirdPromise.promisify<fs.Stats, fs.PathLike>(fs.stat);
 export const statSync = fs.statSync;
 export const fstat = BlueBirdPromise.promisify(fs.fstat);
 export const fstatSync = fs.fstatSync;
@@ -554,7 +554,7 @@ export const ftruncate = BlueBirdPromise.promisify(fs.ftruncate);
 export const ftruncateSync = fs.ftruncateSync;
 
 // unlink
-export const unlink = BlueBirdPromise.promisify(fs.unlink);
+export const unlink = BlueBirdPromise.promisify<void, fs.PathLike>(fs.unlink);
 export const unlinkSync = fs.unlinkSync;
 
 // utimes

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -230,7 +230,7 @@ export function escapeFileContent(content) {
   return escapeBOM(escapeEOL(content));
 }
 
-export type ReadFileOptions = { encoding?: string | null; flag?: string; escape?: string }
+export type ReadFileOptions = { encoding?: BufferEncoding | null; flag?: string; escape?: string }
 
 async function _readFile(path: string, options: ReadFileOptions | null = {}) {
   if (!Object.prototype.hasOwnProperty.call(options,
@@ -431,9 +431,9 @@ export function ensurePathSync(path: string) {
   return _findUnusedPath(path, files);
 }
 
-export function ensureWriteStream(path: string, options?: string | {
+export function ensureWriteStream(path: string, options?: BufferEncoding | {
   flags?: string;
-  encoding?: string;
+  encoding?: BufferEncoding;
   fd?: number;
   mode?: number;
   autoClose?: boolean;
@@ -447,9 +447,9 @@ export function ensureWriteStream(path: string, options?: string | {
     .then(() => fs.createWriteStream(path, options));
 }
 
-export function ensureWriteStreamSync(path: string, options?: string | {
+export function ensureWriteStreamSync(path: string, options?: BufferEncoding | {
   flags?: string;
-  encoding?: string;
+  encoding?: BufferEncoding;
   fd?: number;
   mode?: number;
   autoClose?: boolean;
@@ -575,5 +575,3 @@ export const writeSync = fs.writeSync;
 export const Stats = fs.Stats;
 export const ReadStream = fs.ReadStream;
 export const WriteStream = fs.WriteStream;
-export const FileReadStream = fs.FileReadStream;
-export const FileWriteStream = fs.FileWriteStream;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.36",
+    "@types/graceful-fs": "^4.1.5",
     "@types/node": "^18.7.16",
     "@typescript-eslint/eslint-plugin": "^5.36.2",
     "@typescript-eslint/parser": "^5.36.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b",
     "clean": "tsc -b --clean",
     "eslint": "eslint .",
+    "pretest": "npm run clean && npm run build",
     "test": "mocha test/index.js --require ts-node/register",
     "test-cov": "c8 --reporter=lcovonly npm run test"
   },


### PR DESCRIPTION
Breaking changes: `FileReadStream` and `FileWriteStream` are removed. They are kept in `graceful-fs` for compatibility, see https://github.com/isaacs/node-graceful-fs/blob/1f19b0b467e4144260b397343cd60f37c5bdcfda/graceful-fs.js#L273-L274

Removed because they are not actually used by us, and it's a little tricky to suppress typescript warnings of them.